### PR TITLE
Skip to return error when container PID can't be resolved

### DIFF
--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -721,6 +721,7 @@ func (d *DockerRuntime) produceGenericContainerList(ctx context.Context, inputCo
 		if err != nil {
 			// Container may be deleted before getting pid.
 			// We can consider that container has already deleted.
+			log.Warnf("failed to get container pid, skipping producing generic container: %v", err)
 			continue
 		}
 


### PR DESCRIPTION
We have observed that some ContainerLab deployment was failed with the following logs.

```
2024-01-05T01:50:25+09:00   INFO Containerlab v0.0.0 started
2024-01-05T01:50:25+09:00   INFO Parsing & checking topology file: manifest.yml
2024-01-05T01:50:25+09:00   WARN errors during iptables rules install: missing DOCKER-USER iptables chain. See http://containerlab.dev/manual/network/#external-access
                                 Error: could not list containers: container "0b04c3bbbdabed77ca5fa9faf2445eb73971bc31ff18aa1d32b8139b0c2ac6fb" cannot be found
```

We found this error was happened when another Lab was destroying.

When ContainerLab deploys Lab, ContainerLab will call ContainerRuntime to list containers. At first, Docker ContainerRuntime lists all containers running on the node (step1.), and then Docker ContainerRuntime try to resolve Container's PID to generate generic Container structure (step2.). If the container was deleted between step1. and step2., ContainerLab will fails.

This PR changes that logic and make ContainerLab not to return error.